### PR TITLE
2021-10-06 GUARD-2159 Orders Sync: Improve Error Handling, Logging

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -107,4 +107,6 @@ task NuGet Package, Version, {
 	}
 }
 
-task . Init, Build, Package, Zip, NuGet
+task . Init, Build, Package, NuGet
+# Disabled Zip since it's not needed, but crashes
+# task . Init, Build, Package, Zip, NuGet

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 *.ReSharper
 *.docstates
+.vs
 
 #Ignore common build files
 build

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "2.0.11.0" ) ]
+[ assembly : AssemblyVersion( "2.1.0.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "2.1.0.0" ) ]
+[ assembly : AssemblyVersion( "2.1.1.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "2.1.1.0" ) ]
+[ assembly : AssemblyVersion( "2.1.2.0" ) ]

--- a/src/ThreeDCartAccess/SoapApi/Misc/ErrorHelpers.cs
+++ b/src/ThreeDCartAccess/SoapApi/Misc/ErrorHelpers.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using ThreeDCartAccess.Misc;
+
+namespace ThreeDCartAccess.SoapApi.Misc
+{
+	public static class ErrorHelpers
+	{
+		/// <summary>Throw if the response indicates an error</summary>
+		public static void ThrowIfError( XElement ordersResponse, string storeUrl, [ CallerMemberName ] string callerMethodName = "" )
+		{
+			var isResponseInvalid = ordersResponse.Name != null
+						&& ordersResponse.Value != null
+						&& ordersResponse.Name.LocalName == "Error"
+						&& ordersResponse.Value.ToLower().Contains( "error" );
+
+			if( isResponseInvalid )
+			{
+				var exception = new Exception( ordersResponse.Value );
+				ThreeDCartLogger.Log.Trace( exception, "Error for {0}\tStoreUrl:{1}\tResponse:{2}", 
+					callerMethodName, storeUrl, ordersResponse.Value );
+				throw exception;
+			}
+		}
+	}
+}

--- a/src/ThreeDCartAccess/SoapApi/ThreeDCartOrdersService.cs
+++ b/src/ThreeDCartAccess/SoapApi/ThreeDCartOrdersService.cs
@@ -34,8 +34,6 @@ namespace ThreeDCartAccess.SoapApi
 		}
 
 		public bool IsGetNewOrders( DateTime? startDateUtc = null, DateTime? endDateUtc = null )
-		{
-			try
 			{
 				var startDate = this.GetDate( startDateUtc ?? DateTime.UtcNow.AddDays( -30 ) );
 				var endDate = this.GetDate( endDateUtc ?? DateTime.UtcNow );
@@ -43,11 +41,6 @@ namespace ThreeDCartAccess.SoapApi
 					() => this._service.getOrder( this._config.StoreUrl, this._config.UserKey, _batchSize, 1, true, "", "", startDate, endDate, "" ) );
 				return true;
 			}
-			catch( Exception )
-			{
-				return false;
-			}
-		}
 
 		public List< ThreeDCartOrder > GetNewOrders( DateTime startDateUtc, DateTime endDateUtc )
 		{

--- a/src/ThreeDCartAccess/SoapApi/ThreeDCartOrdersService.cs
+++ b/src/ThreeDCartAccess/SoapApi/ThreeDCartOrdersService.cs
@@ -87,6 +87,8 @@ namespace ThreeDCartAccess.SoapApi
 
 				var filtered = this.SetTimeZoneAndFilter( portion.Orders, startDateUtc, endDateUtc );
 				result.AddRange( filtered );
+				if( portion.Orders.Count != _batchSize )
+					break;
 			}
 
 			return result;

--- a/src/ThreeDCartAccess/SoapApi/ThreeDCartProductsService.cs
+++ b/src/ThreeDCartAccess/SoapApi/ThreeDCartProductsService.cs
@@ -31,6 +31,7 @@ namespace ThreeDCartAccess.SoapApi
 			this._webRequestServices = new WebRequestServices();
 		}
 
+		/// <summary>Verify that can get products. Will return true on success and throw on failure.</summary>
 		public bool IsGetProducts()
 		{
 			var parsedResult = this._webRequestServices.Execute< ThreeDCartProducts >( "IsGetProducts", this._config,
@@ -76,6 +77,7 @@ namespace ThreeDCartAccess.SoapApi
 			return result;
 		}
 
+		/// <summary>Verify that can get inventory. Will return true on success and throw on failure.</summary>
 		public bool IsGetInventory()
 		{
 			var parsedResult = this.GetInventoryPageOrAllPages( 1 );

--- a/src/ThreeDCartAccess/SoapApi/ThreeDCartProductsService.cs
+++ b/src/ThreeDCartAccess/SoapApi/ThreeDCartProductsService.cs
@@ -33,16 +33,9 @@ namespace ThreeDCartAccess.SoapApi
 
 		public bool IsGetProducts()
 		{
-			try
-			{
-				var parsedResult = this._webRequestServices.Execute< ThreeDCartProducts >( "IsGetProducts", this._config,
-					() => this._service.getProduct( this._config.StoreUrl, this._config.UserKey, BatchSize, 1, "", "" ) );
-				return true;
-			}
-			catch( Exception )
-			{
-				return false;
-			}
+			var parsedResult = this._webRequestServices.Execute< ThreeDCartProducts >( "IsGetProducts", this._config,
+				() => this._service.getProduct( this._config.StoreUrl, this._config.UserKey, BatchSize, 1, "", "" ) );
+			return true;
 		}
 
 		public IEnumerable< ThreeDCartProduct > GetProducts()
@@ -85,15 +78,8 @@ namespace ThreeDCartAccess.SoapApi
 
 		public bool IsGetInventory()
 		{
-			try
-			{
-				var parsedResult = this.GetInventoryPageOrAllPages( 1 );
-				return true;
-			}
-			catch( Exception )
-			{
-				return false;
-			}
+			var parsedResult = this.GetInventoryPageOrAllPages( 1 );
+			return true;
 		}
 
 		public IEnumerable< ThreeDCartInventory > GetInventory()

--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -83,6 +83,7 @@
     <Compile Include="SoapApi\IThreeDCartOrdersService.cs" />
     <Compile Include="SoapApi\IThreeDCartProductsService.cs" />
     <Compile Include="Misc\ActionPolicies.cs" />
+    <Compile Include="SoapApi\Misc\ErrorHelpers.cs" />
     <Compile Include="SoapApi\Misc\ScriptsBuilder.cs" />
     <Compile Include="Misc\ThreeDCartLogger.cs" />
     <Compile Include="RestApi\Misc\EndpointsBuilder.cs" />

--- a/src/ThreeDCartAccessTests/Orders/SoapApiOrderTests.cs
+++ b/src/ThreeDCartAccessTests/Orders/SoapApiOrderTests.cs
@@ -30,6 +30,10 @@ namespace ThreeDCartAccessTests.Orders
 				this.ThreeDCartFactory = new ThreeDCartFactory();
 				this.Config = new ThreeDCartConfig( testConfig.StoreUrl, testConfig.UserKey, testConfig.TimeZone );
 			}
+
+			System.Net.ServicePointManager.SecurityProtocol |=  System.Net.SecurityProtocolType.Tls12;
+			//Otherwise, get the error
+			//	An error occurred while making the HTTP request to https://api.3dcart.com/cart.asmx. This could be due to the fact that the server certificate is not configured properly with HTTP.SYS in the HTTPS case. This could also be caused by a mismatch of the security binding between the client and the server.
 		}
 
 		[ Test ]

--- a/src/ThreeDCartAccessTests/SoapApi/Misc/ErrorHelpersTests.cs
+++ b/src/ThreeDCartAccessTests/SoapApi/Misc/ErrorHelpersTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using NUnit.Framework;
+using ThreeDCartAccess.SoapApi.Misc;
+
+namespace ThreeDCartAccessTests.SoapApi.Misc
+{
+	public class ErrorHelpersTests
+	{
+		[ Test ]
+		public void ThrowIfError_ShouldThrowIfErrorInResponse()
+		{
+			var responseWithError = new XElement( XName.Get( "Error" ) ) 
+			{
+				Value = "Error trying to get data from the store. Technical description: First request failed.<html>\n  <body>..."
+			};
+			const string storeUrl = "www.some-store.abc";
+
+			Assert.Throws< Exception >(() => 
+				ErrorHelpers.ThrowIfError( responseWithError, storeUrl ) );
+		}
+	}
+}

--- a/src/ThreeDCartAccessTests/ThreeDCartAccessTests.csproj
+++ b/src/ThreeDCartAccessTests/ThreeDCartAccessTests.csproj
@@ -74,6 +74,7 @@
     </Compile>
     <Compile Include="RestApiTestConfig.cs" />
     <Compile Include="SoapApiTestConfig.cs" />
+    <Compile Include="SoapApi\Misc\ErrorHelpersTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
- GetNewOrdersAsync: If errors are returned from 3d Cart then log & throw (ThrowIfError), instead of requesting subsequent pages FOREVER
- Added tests for ThrowIfError
- Don't absorb IsGet Products / Inventory / NewOrders , so that the caller could log the exception

Other improvements
- Added .vs to .gitignore
- Removed zip from .build.ps1
- SoapApiOrderTests.cs: Added SecurityProtocol |= System.Net.SecurityProtocolType.Tls12 to test setup, since otherwise it throws 
Version 2.1.0