### PR TITLE
GUARD-2792 Automate NuGet package pushing

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,61 @@
+name: Continuous Integration/Continous Deployment
+
+# Runs when a pull request (against master branch) is opened, reopened or when the master branch is updated or when a release tag is created.
+on:
+  pull_request:
+    branches:
+      - master
+  create:
+    branches:
+      - release/**
+
+jobs:
+  build:
+    
+    env:
+      BUILD_CONFIG: 'Release'
+      SOLUTION_NAME: '.\src\ThreeDCartAccess.sln'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET Core SDK 6.x
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 6.x
+
+      - name: Setup DotCover
+        run: dotnet tool install JetBrains.dotCover.GlobalTool -g
+
+      - name: Install dependencies
+        run: dotnet restore $SOLUTION_NAME
+
+      - name: Get build version
+        run: |
+          Import-Module .\build\GetBuildVersion.psm1
+          Write-Host $Env:GITHUB_REF
+          $version = GetBuildVersion -VersionString $Env:GITHUB_REF
+          echo "BUILD_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        shell: pwsh
+
+      - name: Build
+        run: dotnet build $SOLUTION_NAME --configuration $BUILD_CONFIG -p:Version=$BUILD_VERSION --no-restore
+
+      - name: Unit tests
+        run: dotnet dotcover test --no-restore --verbosity normal --dcReportType=HTML --dcOutput="test-results/ThreeDCartAccessTests.html" ".\src\ThreeDCartAccessTests\ThreeDCartAccessTests.csproj"
+
+      - name: Archive code coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: test-results
+
+      - name: Authenticate with Github package repo
+        if: startsWith(github.ref, 'refs/tags')
+        run: dotnet nuget add source --username SkuVault --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/skuvault-integrations/index.json"
+
+      - name: Publish to package repository
+        if: startsWith(github.ref, 'refs/tags')
+        run: dotnet nuget push **\*.$BUILD_VERSION.nupkg --source "github"

--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,11 @@ _ReSharper*/
 .vs
 
 #Ignore common build files
-build
+#Need to include build/GetBuildVersion.psm1
+#build
 log
 packages
+
 *Credentials*.csv
 # JetBrains Rider
 .idea/

--- a/build/GetBuildVersion.psm1
+++ b/build/GetBuildVersion.psm1
@@ -1,0 +1,35 @@
+# This file is required for the CI/CD pipeline to work in Github
+Function GetBuildVersion {
+    Param (
+        [string]$VersionString
+    )
+
+    # Process through regex
+    $VersionString -match "(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?(\-(?<pre>[0-9A-Za-z\-\.]+))?(\+(?<build>\d+))?" | Out-Null
+
+    if ($matches -eq $null) {
+        return "1.0.0-build"
+    }
+
+    # Extract the build metadata
+    $BuildRevision = [uint64]$matches['build']
+    # Extract the pre-release tag
+    $PreReleaseTag = [string]$matches['pre']
+    # Extract the patch
+    $Patch = [uint64]$matches['patch']
+    # Extract the minor
+    $Minor = [uint64]$matches['minor']
+    # Extract the major
+    $Major = [uint64]$matches['major']
+
+    $Version = [string]$Major + '.' + [string]$Minor + '.' + [string]$Patch;
+    if ($PreReleaseTag -ne [string]::Empty) {
+        $Version = $Version + '-' + $PreReleaseTag
+    }
+
+    if ($BuildRevision -ne 0) {
+        $Version = $Version + '.' + [string]$BuildRevision
+    }
+
+    return $Version
+}

--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -12,10 +12,8 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/3dCartAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/3dCartAccess</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/3dCartAccess/blob/master/License.txt</PackageLicenseUrl>
-    <Version>2.2.0-alpha.0</Version>
+    <Version>1.0.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>2.2.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
     <Description>3dCart webservices API wrapper.</Description>
     <Copyright>Copyright (C) 2023 SkuVault Inc.</Copyright>
   </PropertyGroup>


### PR DESCRIPTION
[GUARD-2792]

Automate GitHub NuGet package pushing.

### Background
Per https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/3314876435/Automating+NuGet+package+publishing & based on the example of https://github.com/skuvault-integrations/skuvault-etsy-access-v2/pull/20

NOTE: This is branched off of the [GUARD-2792-Migrate-to-Net-Standard branch](https://github.com/skuvault-integrations/3dCartAccess/tree/GUARD-2792-Migrate-to-Net-Standard), which is yet to be merged into the trunk. Temporarily target it in this PR. Will change to the trunk later.

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [ ] Followed [development conventions][1] to the best of my ability
- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [ ] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [ ] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions
