### PR TITLE
GUARD-2792 2 Follow-Up Remove References to .NET Standard Assemblies

### DIFF
--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -12,10 +12,10 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/3dCartAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/3dCartAccess</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/3dCartAccess/blob/master/License.txt</PackageLicenseUrl>
-    <Version>2.2.0-alpha.1</Version>
+    <Version>2.2.0-alpha.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>2.2.0.1</AssemblyVersion>
-    <FileVersion>2.2.0.1</FileVersion>
+    <AssemblyVersion>2.2.0.2</AssemblyVersion>
+    <FileVersion>2.2.0.2</FileVersion>
     <Description>3dCart webservices API wrapper.</Description>
     <Copyright>Copyright (C) 2023 SkuVault Inc.</Copyright>
   </PropertyGroup>
@@ -36,16 +36,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="RestApi\IThreeDCartOrdersService.cs" />
     <Compile Include="RestApi\Models\Configuration\RestThreeDCartConfig.cs" />


### PR DESCRIPTION
[GUARD-2792]

Summary: Remove explicit references to assemblies included in .NET Standard

## Background

After migrating to .NET Standard (PR https://github.com/skuvault-integrations/3dCartAccess/pull/4), there were new warnings "[MSB3245]" / "[MSB3243]" about core .NET assemblies:
![Screenshot 2023-06-07 102204](https://github.com/skuvault-integrations/3dCartAccess/assets/47125663/a46aecda-8a04-41a2-84e7-e54ec07e921f)

## About these changes

[v. 2.2.0-alpha.2]: Remove explicit references to assemblies included in .NET Standard. This resolves the "[MSB3245]" / "[MSB3243]" warnings. Now, there only "[NU...]" warnings, which are normal for multi-target projects. Was able to reference this package in v1 (pre-release).

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [ ] Followed [development conventions][1] to the best of my ability
- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [ ] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [ ] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions
