### PR TITLE
GUARD-3019 Revert Netco Upgrade

### DIFF
--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -196,7 +196,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Netco" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="Netco" Version="2.0.2" PrivateAssets="All" />
     <PackageReference Include="ServiceStack.Text" Version="6.2.0" />
     <PackageReference Include="skuvault.integrations.core" Version="1.1.0" />
     <PackageReference Include="System.ServiceModel.Web" Version="1.0.0" PrivateAssets="All" />

--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -12,10 +12,10 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/3dCartAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/3dCartAccess</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/3dCartAccess/blob/master/License.txt</PackageLicenseUrl>
-    <Version>2.3.0-alpha.4</Version>
+    <Version>2.3.0-alpha.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>2.3.0.4</AssemblyVersion>
-    <FileVersion>2.3.0.4</FileVersion>
+    <AssemblyVersion>2.3.0.5</AssemblyVersion>
+    <FileVersion>2.3.0.5</FileVersion>
     <Description>3dCart webservices API wrapper.</Description>
     <Copyright>Copyright (C) 2023 SkuVault Inc.</Copyright>
   </PropertyGroup>
@@ -196,6 +196,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="CuttingEdge.Conditions" Version="1.2.0" />
     <PackageReference Include="Netco" Version="2.0.2" PrivateAssets="All" />
     <PackageReference Include="ServiceStack.Text" Version="6.2.0" />
     <PackageReference Include="skuvault.integrations.core" Version="1.1.0" />

--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -12,10 +12,10 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/3dCartAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/3dCartAccess</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/3dCartAccess/blob/master/License.txt</PackageLicenseUrl>
-    <Version>2.3.0-alpha.3</Version>
+    <Version>2.3.0-alpha.4</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>2.3.0.3</AssemblyVersion>
-    <FileVersion>2.3.0.3</FileVersion>
+    <AssemblyVersion>2.3.0.4</AssemblyVersion>
+    <FileVersion>2.3.0.4</FileVersion>
     <Description>3dCart webservices API wrapper.</Description>
     <Copyright>Copyright (C) 2023 SkuVault Inc.</Copyright>
   </PropertyGroup>

--- a/src/ThreeDCartAccessTests/ThreeDCartAccessTests.csproj
+++ b/src/ThreeDCartAccessTests/ThreeDCartAccessTests.csproj
@@ -45,8 +45,8 @@
       <HintPath>..\packages\LINQtoCSV.1.5.0.0\lib\net35\LINQtoCSV.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="Netco, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9d732c15ac2ec2c9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Netco.3.0.0\lib\netstandard2.0\Netco.dll</HintPath>
+    <Reference Include="Netco, Version=2.0.2.0, Culture=neutral, PublicKeyToken=9d732c15ac2ec2c9, processorArchitecture=MSIL">
+      <HintPath>..\packages\Netco.2.0.2\lib\net48\Netco.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.13.3\lib\net45\nunit.framework.dll</HintPath>

--- a/src/ThreeDCartAccessTests/ThreeDCartAccessTests.csproj
+++ b/src/ThreeDCartAccessTests/ThreeDCartAccessTests.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CuttingEdge.Conditions, Version=1.2.0.11174, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\packages\CuttingEdge.Conditions.1.2.0.0\lib\NET35\CuttingEdge.Conditions.dll</HintPath>
+    </Reference>
     <Reference Include="FluentAssertions, Version=4.6.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.4.6.1\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>

--- a/src/ThreeDCartAccessTests/packages.config
+++ b/src/ThreeDCartAccessTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FluentAssertions" version="4.6.1" targetFramework="net451" />
   <package id="LINQtoCSV" version="1.5.0.0" targetFramework="net451" />
-  <package id="Netco" version="3.0.0" targetFramework="net48" />
+  <package id="Netco" version="2.0.2" targetFramework="net48" />
   <package id="NUnit" version="3.13.3" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
 </packages>

--- a/src/ThreeDCartAccessTests/packages.config
+++ b/src/ThreeDCartAccessTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CuttingEdge.Conditions" version="1.2.0.0" targetFramework="net48" />
   <package id="FluentAssertions" version="4.6.1" targetFramework="net451" />
   <package id="LINQtoCSV" version="1.5.0.0" targetFramework="net451" />
   <package id="Netco" version="2.0.2" targetFramework="net48" />


### PR DESCRIPTION
[GUARD-3019]

Summary: Downgrade Netco back to 2.0.2, to resolve v1 warnings and get this trunk to a stable state

#### Background
The previous [Netco upgrade](https://github.com/skuvault-integrations/3dCartAccess/pull/10) to 3.0.0 (.NET Standard) caused build warnings and runtime exceptions in the v1 app, due to inconsistent version of Netco used in different parts of the app. Many places use Netco 2.0.2

#### About these changes
- Downgrade Netco back to 2.0.2 (.NET Framework), to resolve v1 warnings and get this trunk to a stable state. Just reverted [this commit](https://github.com/skuvault-integrations/3dCartAccess/pull/10/commits/35ef45f3aafb67e5285d62d29aaafe38600cedcc) and incremented the package version.
NOTE: Netco will be completely removed from 3dCartAccess in [TD-257](https://agileharbor.atlassian.net/browse/TD-257), making this solution .NET Standard compatible
- Re-add CuttingEdge.Conditions to both projects since integration tests were failing without it being referenced explicitly

### PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [ ] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [x] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [ ] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3019]: https://agileharbor.atlassian.net/browse/GUARD-3019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TD-257]: https://agileharbor.atlassian.net/browse/TD-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ