### PR TITLE
GUARD-3057 Temporarily-Implement-Netco-DoInBatchAsync-ProcessInBatchAsync-in-3dCartAccess

### DIFF
--- a/src/ThreeDCartAccess/Extensions/BatchDetails.cs
+++ b/src/ThreeDCartAccess/Extensions/BatchDetails.cs
@@ -18,9 +18,6 @@ public class BatchDetails< TInput, TResult >
 		ValidationHelper.ThrowOnValidationErrors< BatchDetails< TInput, TResult > >( GetValidationErrors() );
 	}
 
-	//TODO GUARD-3057 Add tests
-	// Condition.Requires( batchSize, "batchSize" ).IsGreaterOrEqual( 1 );
-	// Condition.Requires( processor, "processor" ).IsNotNull();
 	private IEnumerable< string > GetValidationErrors()
 	{
 		var validationErrors = new List< string >();
@@ -51,9 +48,6 @@ public class BatchDetails< TInput >
 		ValidationHelper.ThrowOnValidationErrors< BatchDetails< TInput, Task > >( GetValidationErrors() );
 	}
 
-	//TODO GUARD-3057 Add tests
-	// Condition.Requires( batchSize, "batchSize" ).IsGreaterOrEqual( 1 );
-	// Condition.Requires( processor, "processor" ).IsNotNull();
 	private IEnumerable< string > GetValidationErrors()
 	{
 		var validationErrors = new List< string >();

--- a/src/ThreeDCartAccess/Extensions/BatchDetails.cs
+++ b/src/ThreeDCartAccess/Extensions/BatchDetails.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SkuVault.Integrations.Core.Helpers;
+
+namespace ThreeDCartAccess.Extensions;
+
+public class BatchDetails< TInput, TResult >
+{
+	public readonly int BatchSize;
+	public readonly Func< TInput, Task< TResult > > Processor;
+
+	public BatchDetails( int batchSize, Func< TInput, Task< TResult > > processor )
+	{
+		this.BatchSize = batchSize;
+		this.Processor = processor;
+
+		ValidationHelper.ThrowOnValidationErrors< BatchDetails< TInput, TResult > >( GetValidationErrors() );
+	}
+
+	//TODO GUARD-3057 Add tests
+	// Condition.Requires( batchSize, "batchSize" ).IsGreaterOrEqual( 1 );
+	// Condition.Requires( processor, "processor" ).IsNotNull();
+	private IEnumerable< string > GetValidationErrors()
+	{
+		var validationErrors = new List< string >();
+		if( this.BatchSize < 1 )
+		{
+			validationErrors.Add( $"{nameof(this.BatchSize)} is less than 1" );
+		}
+
+		if( this.Processor == null )
+		{
+			validationErrors.Add( $"{nameof(this.Processor)} is null" );
+		}
+
+		return validationErrors;
+	}
+}
+
+public class BatchDetails< TInput >
+{
+	internal readonly int BatchSize;
+	internal readonly Func< TInput, Task > Processor;
+
+	public BatchDetails( int batchSize, Func< TInput, Task > processor )
+	{
+		this.BatchSize = batchSize;
+		this.Processor = processor;
+
+		ValidationHelper.ThrowOnValidationErrors< BatchDetails< TInput, Task > >( GetValidationErrors() );
+	}
+
+	//TODO GUARD-3057 Add tests
+	// Condition.Requires( batchSize, "batchSize" ).IsGreaterOrEqual( 1 );
+	// Condition.Requires( processor, "processor" ).IsNotNull();
+	private IEnumerable< string > GetValidationErrors()
+	{
+		var validationErrors = new List< string >();
+		if( this.BatchSize < 1 )
+		{
+			validationErrors.Add( $"{nameof(this.BatchSize)} is less than 1" );
+		}
+
+		if( this.Processor == null )
+		{
+			validationErrors.Add( $"{nameof(this.Processor)} is null" );
+		}
+
+		return validationErrors;
+	}
+}

--- a/src/ThreeDCartAccess/Extensions/EnumerableExtensions.cs
+++ b/src/ThreeDCartAccess/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ThreeDCartAccess.Extensions;
+
+//TODO In TD-270 the below methods will be moved to Integrations.Core
+//TODO TD-271 Call the instances in Integrations.Core and remove these methods and related code (tests)
+//TODO GUARD-3057 Add integration tests
+internal static class EnumerableExtensions
+{
+	/// <summary>
+	/// Performs an asynchronous action on each element of enumerable in a batch.
+	/// </summary>
+	/// <typeparam name="TInput">The type of the input.</typeparam>
+	/// <param name="inputEnumerable">The input enumerable.</param>
+	/// <param name="batchSize">Size of the batch.</param>
+	/// <param name="processor">The processor.</param>
+	/// <returns>Task indicating when all action have been performed.</returns>
+	public static async Task DoInBatchesAsync< TInput >( this IEnumerable< TInput > inputEnumerable, int batchSize, Func< TInput, Task > processor )
+	{
+		var batchDetails = new BatchDetails< TInput >( batchSize, processor );
+
+		await DoInBatchesAsync( inputEnumerable, batchDetails ).ConfigureAwait( false );
+	}
+
+	private static async Task DoInBatchesAsync< TInput >( this IEnumerable< TInput > inputEnumerable, BatchDetails< TInput > batchDetails )
+	{
+		if( inputEnumerable == null )
+			return;
+
+		var processingTasks = new List< Task >( batchDetails.BatchSize );
+
+		foreach( var input in inputEnumerable )
+		{
+			processingTasks.Add( batchDetails.Processor( input ) );
+
+			if( processingTasks.Count == batchDetails.BatchSize ) // batch size reached, wait for completion and process
+			{
+				await Task.WhenAll( processingTasks ).ConfigureAwait( false );
+				processingTasks.Clear();
+			}
+		}
+
+		await Task.WhenAll( processingTasks ).ConfigureAwait( false );
+	}
+
+	/// <summary>
+	/// Processes elements asynchronously the in batch of the specified size.
+	/// </summary>
+	/// <typeparam name="TInput">The type of the input.</typeparam>
+	/// <typeparam name="TResult">The type of the result.</typeparam>
+	/// <param name="inputEnumerable">The input enumerable.</param>
+	/// <param name="batchSize">Size of the batch.</param>
+	/// <param name="processor">The processor.</param>
+	/// <param name="ignoreNull">if set to <c>true</c> and <paramref name="processor"/> returns <c>null</c> the result is ignored.</param>
+	/// <returns>Result of processing.</returns>
+	///
+	public static async Task< IEnumerable< TResult > > DoInBatchesAsync< TInput, TResult >( this IEnumerable< TInput > inputEnumerable, int batchSize, Func< TInput, Task< TResult > > processor, bool ignoreNull = true )
+	{
+		var batchDetails = new BatchDetails< TInput, TResult >( batchSize, processor );
+
+		return await DoInBatchesAsync( inputEnumerable, batchDetails, ignoreNull ).ConfigureAwait( false );
+	}
+
+	private static async Task< IEnumerable< TResult > > DoInBatchesAsync< TInput, TResult >( IEnumerable< TInput > inputEnumerable, BatchDetails< TInput, TResult > batchDetails, bool ignoreNull )
+	{
+		if( inputEnumerable == null )
+			return Enumerable.Empty< TResult >();
+
+		var result = new List< TResult >( inputEnumerable.Count() );
+		var processingTasks = new List< Task< TResult > >( batchDetails.BatchSize );
+
+		foreach( var input in inputEnumerable )
+		{
+			processingTasks.Add( batchDetails.Processor( input ) );
+
+			if( processingTasks.Count == batchDetails.BatchSize ) // batch size reached, wait for completion and process
+			{
+				AddResultToList( await Task.WhenAll( processingTasks ).ConfigureAwait( false ), result, ignoreNull );
+				processingTasks.Clear();
+			}
+		}
+
+		AddResultToList( await Task.WhenAll( processingTasks ).ConfigureAwait( false ), result, ignoreNull );
+		return result;
+	}
+
+	private static void AddResultToList< TResult >( IEnumerable< TResult > intermidiateResult, List< TResult > endResult, bool ignoreNull )
+	{
+		foreach( var value in intermidiateResult )
+		{
+			if( ignoreNull && Equals( value, default(TResult) ) )
+				continue;
+
+			endResult.Add( value );
+		}
+	}
+}

--- a/src/ThreeDCartAccess/Extensions/ParallelProcessExtensions.cs
+++ b/src/ThreeDCartAccess/Extensions/ParallelProcessExtensions.cs
@@ -10,12 +10,12 @@ namespace ThreeDCartAccess.Extensions;
 internal static class ParallelProcessExtensions
 {
 	/// <summary>
-	/// Performs an asynchronous action on each element of enumerable in a batch.
+	/// Performs an asynchronous action on each element of enumerable in <paramref name="batchSize"/> of concurrent tasks.
 	/// </summary>
 	/// <typeparam name="TInput">The type of the input.</typeparam>
 	/// <param name="inputEnumerable">The input enumerable.</param>
 	/// <param name="batchSize">Size of the batch.</param>
-	/// <param name="processor">The processor.</param>
+	/// <param name="processor">The processor delegate method.</param>
 	/// <returns>Task indicating when all action have been performed.</returns>
 	public static async Task DoInBatchesAsync< TInput >( this IEnumerable< TInput > inputEnumerable, int batchSize, Func< TInput, Task > processor )
 	{
@@ -46,13 +46,13 @@ internal static class ParallelProcessExtensions
 	}
 
 	/// <summary>
-	/// Processes elements asynchronously the in batch of the specified size.
+	/// Calls an asynchronous function on each element of enumerable in <paramref name="batchSize"/> of concurrent tasks.
 	/// </summary>
 	/// <typeparam name="TInput">The type of the input.</typeparam>
 	/// <typeparam name="TResult">The type of the result.</typeparam>
 	/// <param name="inputEnumerable">The input enumerable.</param>
 	/// <param name="batchSize">Size of the batch.</param>
-	/// <param name="processor">The processor.</param>
+	/// <param name="processor">The processor delegate method.</param>
 	/// <param name="ignoreNull">if set to <c>true</c> and <paramref name="processor"/> returns <c>null</c> the result is ignored.</param>
 	/// <returns>Result of processing.</returns>
 	public static async Task< IEnumerable< TResult > > DoInBatchesAsync< TInput, TResult >( this IEnumerable< TInput > inputEnumerable, int batchSize, Func< TInput, Task< TResult > > processor, bool ignoreNull = true )
@@ -85,9 +85,9 @@ internal static class ParallelProcessExtensions
 		return result;
 	}
 
-	private static void AddResultToList< TResult >( IEnumerable< TResult > intermidiateResult, List< TResult > endResult, bool ignoreNull )
+	private static void AddResultToList< TResult >( IEnumerable< TResult > intermediateResult, List< TResult > endResult, bool ignoreNull )
 	{
-		foreach( var value in intermidiateResult )
+		foreach( var value in intermediateResult )
 		{
 			if( ignoreNull && Equals( value, default(TResult) ) )
 				continue;

--- a/src/ThreeDCartAccess/Extensions/ParallelProcessExtensions.cs
+++ b/src/ThreeDCartAccess/Extensions/ParallelProcessExtensions.cs
@@ -55,7 +55,6 @@ internal static class ParallelProcessExtensions
 	/// <param name="processor">The processor.</param>
 	/// <param name="ignoreNull">if set to <c>true</c> and <paramref name="processor"/> returns <c>null</c> the result is ignored.</param>
 	/// <returns>Result of processing.</returns>
-	///
 	public static async Task< IEnumerable< TResult > > DoInBatchesAsync< TInput, TResult >( this IEnumerable< TInput > inputEnumerable, int batchSize, Func< TInput, Task< TResult > > processor, bool ignoreNull = true )
 	{
 		var batchDetails = new BatchDetails< TInput, TResult >( batchSize, processor );

--- a/src/ThreeDCartAccess/Extensions/ParallelProcessExtensions.cs
+++ b/src/ThreeDCartAccess/Extensions/ParallelProcessExtensions.cs
@@ -7,8 +7,7 @@ namespace ThreeDCartAccess.Extensions;
 
 //TODO In TD-270 the below methods will be moved to Integrations.Core
 //TODO TD-271 Call the instances in Integrations.Core and remove these methods and related code (tests)
-//TODO GUARD-3057 Add integration tests
-internal static class EnumerableExtensions
+internal static class ParallelProcessExtensions
 {
 	/// <summary>
 	/// Performs an asynchronous action on each element of enumerable in a batch.

--- a/src/ThreeDCartAccess/RestApi/ThreeDCartOrdersService.cs
+++ b/src/ThreeDCartAccess/RestApi/ThreeDCartOrdersService.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Netco.Extensions;
+using ThreeDCartAccess.Extensions;
 using ThreeDCartAccess.Misc;
 using ThreeDCartAccess.RestApi.Misc;
 using ThreeDCartAccess.RestApi.Models.Configuration;
@@ -137,7 +137,7 @@ namespace ThreeDCartAccess.RestApi
 		public async Task GetOrdersByNumberAsync( List< string > invoiceNumbers, DateTime startDateUtc, DateTime endDateUtc, Action< ThreeDCartOrder > processAction )
 		{
 			var marker = this.GetMarker();
-			await invoiceNumbers.DoInBatchAsync( 10, async invoiceNumber =>
+			await invoiceNumbers.DoInBatchesAsync( 10, async invoiceNumber =>
 			{
 				var endpoint = EndpointsBuilder.GetOrderEndpoint( invoiceNumber );
 				var portion = await ActionPolicies.GetAsync.Get( async () => await this.WebRequestServices.GetResponseAsync< List< ThreeDCartOrder > >( endpoint, marker ) );

--- a/src/ThreeDCartAccess/SoapApi/ThreeDCartOrdersService.cs
+++ b/src/ThreeDCartAccess/SoapApi/ThreeDCartOrdersService.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
-using Netco.Extensions;
 using SkuVault.Integrations.Core.Helpers;
+using ThreeDCartAccess.Extensions;
 using ThreeDCartAccess.Misc;
 using ThreeDCartAccess.SoapApi.Misc;
 using ThreeDCartAccess.SoapApi.Models.Configuration;
@@ -118,7 +118,7 @@ namespace ThreeDCartAccess.SoapApi
 
 		public async Task< List< ThreeDCartOrder > > GetOrdersByNumberAsync( List< string > invoiceNumbers, DateTime startDateUtc, DateTime endDateUtc )
 		{
-			var orders = await invoiceNumbers.ProcessInBatchAsync( 50, async invoiceNumber =>
+			var orders = await invoiceNumbers.DoInBatchesAsync( 50, async invoiceNumber =>
 			{
 				var order = await this.GetOrderByNumberAsync( invoiceNumber.Trim() );
 				return order;

--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -12,10 +12,10 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/3dCartAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/3dCartAccess</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/3dCartAccess/blob/master/License.txt</PackageLicenseUrl>
-    <Version>2.3.0-alpha.5</Version>
+    <Version>2.3.1-alpha.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>2.3.0.5</AssemblyVersion>
-    <FileVersion>2.3.0.5</FileVersion>
+    <AssemblyVersion>2.3.1.1</AssemblyVersion>
+    <FileVersion>2.3.1.1</FileVersion>
     <Description>3dCart webservices API wrapper.</Description>
     <Copyright>Copyright (C) 2023 SkuVault Inc.</Copyright>
   </PropertyGroup>
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Extensions\BatchDetails.cs" />
-    <Compile Include="Extensions\EnumerableExtensions.cs" />
+    <Compile Include="Extensions\ParallelProcessExtensions.cs" />
     <Compile Include="RestApi\IThreeDCartOrdersService.cs" />
     <Compile Include="RestApi\Models\Configuration\RestThreeDCartConfig.cs" />
     <Compile Include="RestApi\Models\Order\ThreeDCartOrderItem.cs" />

--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -12,10 +12,10 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/3dCartAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/3dCartAccess</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/3dCartAccess/blob/master/License.txt</PackageLicenseUrl>
-    <Version>2.3.1-alpha.1</Version>
+    <Version>2.3.1-alpha.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>2.3.1.1</AssemblyVersion>
-    <FileVersion>2.3.1.1</FileVersion>
+    <AssemblyVersion>2.3.1.2</AssemblyVersion>
+    <FileVersion>2.3.1.2</FileVersion>
     <Description>3dCart webservices API wrapper.</Description>
     <Copyright>Copyright (C) 2023 SkuVault Inc.</Copyright>
   </PropertyGroup>

--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -12,10 +12,10 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/3dCartAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/3dCartAccess</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/3dCartAccess/blob/master/License.txt</PackageLicenseUrl>
-    <Version>2.3.1-alpha.2</Version>
+    <Version>2.3.1-alpha.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>2.3.1.2</AssemblyVersion>
-    <FileVersion>2.3.1.2</FileVersion>
+    <AssemblyVersion>2.3.1.3</AssemblyVersion>
+    <FileVersion>2.3.1.3</FileVersion>
     <Description>3dCart webservices API wrapper.</Description>
     <Copyright>Copyright (C) 2023 SkuVault Inc.</Copyright>
   </PropertyGroup>

--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -37,6 +37,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Extensions\BatchDetails.cs" />
+    <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="RestApi\IThreeDCartOrdersService.cs" />
     <Compile Include="RestApi\Models\Configuration\RestThreeDCartConfig.cs" />
     <Compile Include="RestApi\Models\Order\ThreeDCartOrderItem.cs" />

--- a/src/ThreeDCartAccessTests/Extensions/BatchDetailsTInputTResultTests.cs
+++ b/src/ThreeDCartAccessTests/Extensions/BatchDetailsTInputTResultTests.cs
@@ -14,7 +14,6 @@ namespace ThreeDCartAccessTests.Extensions
 
 		[ TestCase( -1 ) ]
 		[ TestCase( 0 ) ]
-		[ TestCase( null ) ]
 		public void Constructor_ShouldThrow_WhenBatchSizeIsBelowOne( int batchSize )
 		{
 			Assert.Throws< ArgumentException >( () => new BatchDetails< int, int >( batchSize, validProcessor ) );

--- a/src/ThreeDCartAccessTests/Extensions/BatchDetailsTInputTResultTests.cs
+++ b/src/ThreeDCartAccessTests/Extensions/BatchDetailsTInputTResultTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using ThreeDCartAccess.Extensions;
+
+namespace ThreeDCartAccessTests.Extensions
+{
+	public class BatchDetailsTInputTResultTests
+	{
+		private static readonly Randomizer _randomizer = new Randomizer();
+		private readonly int validBatchSize = ( int )_randomizer.NextUInt( 1, int.MaxValue );
+		private Func< int, Task< int > > validProcessor => i => Task.FromResult( 0 );
+
+		[ TestCase( -1 ) ]
+		[ TestCase( 0 ) ]
+		[ TestCase( null ) ]
+		public void Constructor_ShouldThrow_WhenBatchSizeIsBelowOne( int batchSize )
+		{
+			Assert.Throws< ArgumentException >( () => new BatchDetails< int, int >( batchSize, validProcessor ) );
+		}
+
+		[ Test ]
+		public void Constructor_ShouldThrow_WhenProcessorIsNull()
+		{
+			Assert.Throws< ArgumentException >( () => new BatchDetails< int, int >( validBatchSize, processor : null ) );
+		}
+
+		[ Test ]
+		public void Constructor_ShouldNotThrow_WhenAllParamsAreValid()
+		{
+			Assert.DoesNotThrow( () => new BatchDetails< int, int >( validBatchSize, validProcessor ) );
+		}
+
+		[ Test ]
+		public void Constructor_ShouldNotThrow_WhenProcessorIsValid_andBatchSizeIsMinimumAllowed()
+		{
+			Assert.DoesNotThrow( () => new BatchDetails< int, int >( 1, validProcessor ) );
+		}
+	}
+}

--- a/src/ThreeDCartAccessTests/Extensions/BatchDetailsTInputTests.cs
+++ b/src/ThreeDCartAccessTests/Extensions/BatchDetailsTInputTests.cs
@@ -14,7 +14,6 @@ namespace ThreeDCartAccessTests.Extensions
 
 		[ TestCase( -1 ) ]
 		[ TestCase( 0 ) ]
-		[ TestCase( null ) ]
 		public void Constructor_ShouldThrow_WhenBatchSizeIsBelowOne( int batchSize )
 		{
 			Assert.Throws< ArgumentException >( () => new BatchDetails< int >( batchSize, validProcessor ) );

--- a/src/ThreeDCartAccessTests/Extensions/BatchDetailsTInputTests.cs
+++ b/src/ThreeDCartAccessTests/Extensions/BatchDetailsTInputTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using ThreeDCartAccess.Extensions;
+
+namespace ThreeDCartAccessTests.Extensions
+{
+	public class BatchDetailsTInputTests
+	{
+		private static readonly Randomizer _randomizer = new Randomizer();
+		private readonly int validBatchSize = ( int )_randomizer.NextUInt( 1, int.MaxValue );
+		private Func< int, Task > validProcessor => i => Task.CompletedTask;
+
+		[ TestCase( -1 ) ]
+		[ TestCase( 0 ) ]
+		[ TestCase( null ) ]
+		public void Constructor_ShouldThrow_WhenBatchSizeIsBelowOne( int batchSize )
+		{
+			Assert.Throws< ArgumentException >( () => new BatchDetails< int >( batchSize, validProcessor ) );
+		}
+
+		[ Test ]
+		public void Constructor_ShouldThrow_WhenProcessorIsNull()
+		{
+			Assert.Throws< ArgumentException >( () => new BatchDetails< int >( validBatchSize, processor : null ) );
+		}
+
+		[ Test ]
+		public void Constructor_ShouldNotThrow_WhenAllParamsAreValid()
+		{
+			Assert.DoesNotThrow( () => new BatchDetails< int >( validBatchSize, validProcessor ) );
+		}
+
+		[ Test ]
+		public void Constructor_ShouldNotThrow_WhenProcessorIsValid_andBatchSizeIsMinimumAllowed()
+		{
+			Assert.DoesNotThrow( () => new BatchDetails< int >( 1, validProcessor ) );
+		}
+	}
+}

--- a/src/ThreeDCartAccessTests/Extensions/ParallelProcessExtensionsTests.cs
+++ b/src/ThreeDCartAccessTests/Extensions/ParallelProcessExtensionsTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ThreeDCartAccess.Extensions;
+
+namespace ThreeDCartAccessTests.Extensions
+{
+	public class ParallelProcessExtensionsTests
+	{
+		[ Test ]
+		public async Task DoInBatchesAsyncOverloadWithReturnValue_ShouldReturnCorrectValues()
+		{
+			var items = new List< int > { 1, 2, 3, 4, 5 };
+			const int batchSize = 2;
+			const int multiplier = 2;
+			Func< int, Task< int > > processor = i => Task.FromResult( i * multiplier );
+
+			var result = await items.DoInBatchesAsync( batchSize, processor ).ConfigureAwait( false );
+
+			Assert.That( result, Is.EqualTo( items.Select( x => x * multiplier ) ) );
+		}
+
+		[ Test ]
+		public async Task DoInBatchesAsyncOverloadWithoutReturnValue_ShouldCallProcessorWithCorrectValues()
+		{
+			var inputItems = new List< int > { 1, 2, 3, 4, 5 };
+			var observedCalls = new List< int >();
+			const int batchSize = 2;
+			Func< int, Task > processor = i => 
+			{
+				observedCalls.Add( i );
+				return Task.CompletedTask;
+			};
+
+			await inputItems.DoInBatchesAsync( batchSize, processor ).ConfigureAwait( false );
+
+			Assert.That( observedCalls, Is.EqualTo( inputItems ) );
+		}
+	}
+}

--- a/src/ThreeDCartAccessTests/ThreeDCartAccessTests.csproj
+++ b/src/ThreeDCartAccessTests/ThreeDCartAccessTests.csproj
@@ -67,6 +67,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseRestApiTests.cs" />
+    <Compile Include="Extensions\BatchDetailsTInputTests.cs" />
+    <Compile Include="Extensions\BatchDetailsTInputTResultTests.cs" />
+    <Compile Include="Extensions\ParallelProcessExtensionsTests.cs" />
     <Compile Include="Integration\Orders\RestApiOrderTests.cs" />
     <Compile Include="Integration\Orders\SoapApiOrderTests.cs" />
     <Compile Include="Integration\Products\RestApiProductTests.cs" />


### PR DESCRIPTION
[GUARD-3057]
Summary: Temporarily implement the Netco DoInBatchAsync and ProcessInBatchAsync in 3dCartAccess

#### Background
Per discussion with Core, we have to stop using Netco. [Chris said it's Ok](https://skuvault.slack.com/archives/CHUENCZ3L/p1692129287319279) to move these methods to Integrations.Core ([TD-270]) and then reference them from this repo ([TD-271]).

#### About these changes
Since we don't want to pause GUARD-3057 until the TD- tickets above, for now we did:
- Implement the Netco DoInBatchAsync, ProcessInBatchAsync in 3dCartAccess
  - Create BatchDetails class to validate method params since our current pattern is constructor validation
- Create unit tests for parameter validation and calls to these new methods

### PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [ ] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [x] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [x] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3057]: https://agileharbor.atlassian.net/browse/GUARD-3057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TD-270]: https://agileharbor.atlassian.net/browse/TD-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TD-271]: https://agileharbor.atlassian.net/browse/TD-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ