### PR TITLE
GUARD-3057 Remove -alpha from package version

### DIFF
--- a/src/ThreeDCartAccess/ThreeDCartAccess.csproj
+++ b/src/ThreeDCartAccess/ThreeDCartAccess.csproj
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/3dCartAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/3dCartAccess</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/3dCartAccess/blob/master/License.txt</PackageLicenseUrl>
-    <Version>2.3.1-alpha.4</Version>
+    <Version>2.3.1.4</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>2.3.1.4</AssemblyVersion>
     <FileVersion>2.3.1.4</FileVersion>


### PR DESCRIPTION
[GUARD-3057]
Summary: Remove -alpha from the package version since GUARD-3057 has been tested in QA

### PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [x] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [x] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [ ] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3057]: https://agileharbor.atlassian.net/browse/GUARD-3057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ